### PR TITLE
Add random flag to damage calculation

### DIFF
--- a/Calculator.cs
+++ b/Calculator.cs
@@ -8,9 +8,14 @@ namespace WeaponRealizer
 
         internal static float ApplyDamageModifiers(AbstractActor attacker, ICombatant target, Weapon weapon, float rawDamage)
         {
+            return ApplyAllDamageModifiers(attacker, target, weapon, rawDamage, true);
+        }
+
+        internal static float ApplyAllDamageModifiers(AbstractActor attacker, ICombatant target, Weapon weapon, float rawDamage, bool random)
+        {
             var damage = rawDamage;
 
-            if (SimpleVariance.IsApplicable(weapon))
+            if (random && SimpleVariance.IsApplicable(weapon))
             {
                 damage = SimpleVariance.Calculate(weapon, rawDamage);
             }


### PR DESCRIPTION
Add new method ApplyAllDamageModifiers, with a flag to control whether to roll randoms in damage calculation.  Requested by Sheepy for damage prediction in AIM.